### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 crewai==0.22.5
 exa_py==1.0.9
 langchain==0.1.13
-python-dotenv==1.0.1
+python-dotenv==1.0.0


### PR DESCRIPTION
Resolving conflict with different versions of python-dotenv:

ERROR: Cannot install python-dotenv==1.0.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested python-dotenv==1.0.1
    crewai 0.22.5 depends on python-dotenv==1.0.0